### PR TITLE
Adding option to prevent tagnames from beeing lowercase.

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -20,7 +20,7 @@ export function format (nodes, options) {
     const outputNode = type === 'element'
       ? {
         type,
-        tagName: node.tagName.toLowerCase(),
+        tagName: options.tagNameToLowerCase ? node.tagName.toLowerCase() : node.tagName,
         attributes: formatAttributes(node.attributes),
         children: format(node.children, options)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ export const parseDefaults = {
   closingTags,
   childlessTags,
   closingTagAncestorBreakers,
-  includePositions: false
+  includePositions: false,
+  tagNameToLowerCase: true
 }
 
 export function parse (str, options = parseDefaults) {

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -63,7 +63,7 @@ export function lex (state) {
         lexComment(state)
       } else {
         const tagName = lexTag(state)
-        const safeTag = tagName.toLowerCase()
+        const safeTag = state.options.tagNameToLowerCase ? tagName.toLowerCase() : tagName
         if (arrayIncludes(childlessTags, safeTag)) {
           lexSkipTag(tagName, state)
         }
@@ -273,7 +273,7 @@ const push = [].push
 
 export function lexSkipTag (tagName, state) {
   const {str, position, tokens} = state
-  const safeTagName = tagName.toLowerCase()
+  const safeTagName = state.options.tagNameToLowerCase ? tagName.toLowerCase() : tagName
   const len = str.length
   let index = position.index
   while (index < len) {
@@ -286,8 +286,8 @@ export function lexSkipTag (tagName, state) {
     const tagStartPosition = copyPosition(position)
     jumpPosition(tagStartPosition, str, nextTag)
     const tagState = {str, position: tagStartPosition, tokens: []}
-    const name = lexTag(tagState)
-    if (safeTagName !== name.toLowerCase()) {
+    const name = state.options.tagNameToLowerCase ? lexTag(tagState).toLowerCase() : lexTag(tagState)
+    if (safeTagName !== name) {
       index = tagState.position.index
       continue
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -49,7 +49,7 @@ export function parse (state) {
 
     const tagToken = tokens[++cursor]
     cursor++
-    const tagName = tagToken.content.toLowerCase()
+    const tagName = state.options.tagNameToLowerCase ? tagToken.content.toLowerCase() : tagToken.content
     if (token.close) {
       let index = stack.length
       let shouldRewind = false

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -21,10 +21,11 @@ export function toHTML (tree, options) {
       return `<!--${node.content}-->`
     }
     const {tagName, attributes, children} = node
-    const isSelfClosing = arrayIncludes(options.voidTags, tagName.toLowerCase())
+    const safeTagName = options.tagNameToLowerCase ? tagName.toLowerCase() : tagName
+    const isSelfClosing = arrayIncludes(options.voidTags, safeTagName)
     return isSelfClosing
-      ? `<${tagName}${formatAttributes(attributes)}>`
-      : `<${tagName}${formatAttributes(attributes)}>${toHTML(children, options)}</${tagName}>`
+      ? `<${safeTagName}${formatAttributes(attributes)}>`
+      : `<${safeTagName}${formatAttributes(attributes)}>${toHTML(children, options)}</${safeTagName}>`
   }).join('')
 }
 

--- a/test/lexer.js
+++ b/test/lexer.js
@@ -344,7 +344,7 @@ test('lexTagAttributes should handle incomplete attributes', t => {
 test('lexSkipTag should tokenize as text until the matching tag name', t => {
   const str = 'abcd<test><h1>Test case</h1></test><x>'
   const finish = str.indexOf('<x>')
-  const state = {str, position: ps(10), tokens: []}
+  const state = {str, position: ps(10), tokens: [], options: {tagNameToLowerCase: false}}
   lexSkipTag('test', state)
   t.is(state.position.index, finish)
   t.deepEqual(state.tokens, [
@@ -358,7 +358,7 @@ test('lexSkipTag should tokenize as text until the matching tag name', t => {
 test('lexSkipTag should stop at the case-insensitive matching tag name', t => {
   const str = '<tEsT>proving <???> the point</TeSt><x>'
   const finish = str.indexOf('<x>')
-  const state = {str, position: ps(6), tokens: []}
+  const state = {str, position: ps(6), tokens: [], options: {tagNameToLowerCase: true}}
   lexSkipTag('tEsT', state)
   t.is(state.position.index, finish)
   t.deepEqual(state.tokens, [
@@ -371,7 +371,7 @@ test('lexSkipTag should stop at the case-insensitive matching tag name', t => {
 
 test('lexSkipTag should auto-close if the end tag is not found', t => {
   const str = '<script>This never ends'
-  const state = {str, position: ps(8), tokens: []}
+  const state = {str, position: ps(8), tokens: [], options: {tagNameToLowerCase: true}}
   lexSkipTag('script', state)
   t.is(state.position.index, str.length)
   t.deepEqual(state.tokens, [
@@ -381,7 +381,7 @@ test('lexSkipTag should auto-close if the end tag is not found', t => {
 
 test('lexSkipTag should handle finding a stray "</" [resilience]', t => {
   const str = '<script>proving </nothing></script>'
-  const state = {str, position: ps(8), tokens: []}
+  const state = {str, position: ps(8), tokens: [], options: {tagNameToLowerCase: true}}
   lexSkipTag('script', state)
   t.is(state.position.index, str.length)
   t.deepEqual(state.tokens, [
@@ -394,7 +394,7 @@ test('lexSkipTag should handle finding a stray "</" [resilience]', t => {
 
 test('lexSkipTag should not add an empty inner text node', t => {
   const str = '<script></script>'
-  const state = {str, position: ps(8), tokens: []}
+  const state = {str, position: ps(8), tokens: [], options: {tagNameToLowerCase: true}}
   lexSkipTag('script', state)
   t.is(state.position.index, str.length)
   t.deepEqual(state.tokens, [

--- a/test/parser.js
+++ b/test/parser.js
@@ -6,11 +6,12 @@ function ps (index) {
   return { index, line: 0, column: index }
 }
 
-const lexerOptions = { childlessTags: [] }
+const lexerOptions = { childlessTags: [], tagNameToLowerCase: true }
 const parserOptions = {
   voidTags: [],
   closingTags: [],
-  closingTagAncestorBreakers: {}
+  closingTagAncestorBreakers: {},
+  tagNameToLowerCase: true
 }
 
 test('parser() should return nodes', t => {


### PR DESCRIPTION
Example << Angular components html templates >> need to preserve the case of the components tags(selectors)