### PR TITLE
Update stringify.js

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,14 +1,20 @@
 import {arrayIncludes} from './compat'
 
-export function formatAttributes (attributes) {
+export function formatAttributes (attributes, useDoubleQuotes) {
   return attributes.reduce((attrs, attribute) => {
     const {key, value} = attribute
     if (value === null) {
       return `${attrs} ${key}`
     }
-    const quoteEscape = value.indexOf('\'') !== -1
-    const quote = quoteEscape ? '"' : '\''
-    return `${attrs} ${key}=${quote}${value}${quote}`
+    if (useDoubleQuotes) {
+      const quoteEscape = value.indexOf('"') !== -1
+      const quote = quoteEscape ? "'" : '"'
+      return `${attrs} ${key}=${quote}${value}${quote}`
+    } else {
+      const quoteEscape = value.indexOf("'") !== -1
+      const quote = quoteEscape ? '"' : "'"
+      return `${attrs} ${key}=${quote}${value}${quote}`
+    }
   }, '')
 }
 
@@ -23,8 +29,8 @@ export function toHTML (tree, options) {
     const {tagName, attributes, children} = node
     const isSelfClosing = arrayIncludes(options.voidTags, tagName.toLowerCase())
     return isSelfClosing
-      ? `<${tagName}${formatAttributes(attributes)}>`
-      : `<${tagName}${formatAttributes(attributes)}>${toHTML(children, options)}</${tagName}>`
+      ? `<${tagName}${formatAttributes(attributes, options.useDoubleQuotes)}>`
+      : `<${tagName}${formatAttributes(attributes, options.useDoubleQuotes)}>${toHTML(children, options)}</${tagName}>`
   }).join('')
 }
 


### PR DESCRIPTION
Adds the option to use double quotes as a default to surround attributes, certain WYSIWYG editors expect html in this format